### PR TITLE
Improved Mold Station interaction

### DIFF
--- a/src/main/java/exter/foundry/gui/GuiMoldStation.java
+++ b/src/main/java/exter/foundry/gui/GuiMoldStation.java
@@ -11,6 +11,7 @@ import exter.foundry.container.ContainerMoldStation;
 import exter.foundry.gui.button.GuiButtonFoundry;
 import exter.foundry.tileentity.TileEntityMoldStation;
 import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
@@ -60,6 +61,10 @@ public class GuiMoldStation extends GuiFoundry {
 	private GuiButtonFoundry button_fire;
 	private final NonNullList<Boolean> pattern;
 	private int processingState;
+	
+	private final String STRING_MOLD_STATION;
+	private final String STRING_INVENTORY;
+	private final String STRING_FIRE;
 
 	public GuiMoldStation(TileEntityMoldStation af, EntityPlayer player) {
 		super(new ContainerMoldStation(af, player));
@@ -68,6 +73,9 @@ public class GuiMoldStation extends GuiFoundry {
 		te_ms = af;
 		pattern = NonNullList.withSize(36, Boolean.FALSE);
 		processingState = -1; // No state.
+		STRING_MOLD_STATION = I18n.format("gui.foundry.mold");
+		STRING_INVENTORY = I18n.format("container.inventory");
+		STRING_FIRE = I18n.format("gui.foundry.mold.fire");
 	}
 
 	@Override
@@ -120,8 +128,8 @@ public class GuiMoldStation extends GuiFoundry {
 	protected void drawGuiContainerForegroundLayer(int mouse_x, int mouse_y) {
 		super.drawGuiContainerForegroundLayer(mouse_x, mouse_y);
 
-		fontRenderer.drawString("Mold Station", 5, 6, 0x404040);
-		fontRenderer.drawString("Inventory", 8, ySize - 96 + 2, 0x404040);
+		fontRenderer.drawString(STRING_MOLD_STATION, 8, 6, 0x404040);
+		fontRenderer.drawString(STRING_INVENTORY, 8, ySize - 96 + 2, 0x404040);
 	}
 
 	@Override
@@ -140,13 +148,13 @@ public class GuiMoldStation extends GuiFoundry {
 			    depth += (processingState == 0 ? 1 : -1) * (isShiftKeyDown() ? 4 : 1);
             }
 			depth = MathHelper.clamp(depth, TileEntityMoldStation.MIN_DEPTH, TileEntityMoldStation.MAX_DEPTH);
-			currenttip.add("Depth: " + depth);
+			currenttip.add(I18n.format("gui.foundry.mold.depth", depth));
 			drawHoveringText(currenttip, mousex, mousey, fontRenderer);
 		}
 
 		if (isPointInRegion(117, 15, button_fire.width, button_fire.height, mousex, mousey)) {
 			List<String> currenttip = new ArrayList<>(1);
-			currenttip.add("Fire mold");
+			currenttip.add(STRING_FIRE);
 			drawHoveringText(currenttip, mousex, mousey, fontRenderer);
 		}
 	}

--- a/src/main/java/exter/foundry/gui/GuiMoldStation.java
+++ b/src/main/java/exter/foundry/gui/GuiMoldStation.java
@@ -2,6 +2,7 @@ package exter.foundry.gui;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.lwjgl.opengl.GL11;
@@ -11,7 +12,9 @@ import exter.foundry.gui.button.GuiButtonFoundry;
 import exter.foundry.tileentity.TileEntityMoldStation;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -55,12 +58,16 @@ public class GuiMoldStation extends GuiFoundry {
 
 	private final TileEntityMoldStation te_ms;
 	private GuiButtonFoundry button_fire;
+	private final NonNullList<Boolean> pattern;
+	private int processingState;
 
 	public GuiMoldStation(TileEntityMoldStation af, EntityPlayer player) {
 		super(new ContainerMoldStation(af, player));
 		allowUserInput = false;
 		ySize = 190;
 		te_ms = af;
+		pattern = NonNullList.withSize(36, Boolean.FALSE);
+		processingState = -1; // No state.
 	}
 
 	@Override
@@ -96,9 +103,15 @@ public class GuiMoldStation extends GuiFoundry {
 				int gx = i % 6;
 				int gy = i / 6;
 				int sv = te_ms.getGridSlot(i);
-				if (sv > 0) {
-					drawTexturedModalRect(window_x + GRID_X + gx * GRID_SLOT_SIZE, window_y + GRID_Y + gy * GRID_SLOT_SIZE, GRID_OVERLAY_X, GRID_OVERLAY_Y + (sv - 1) * GRID_SLOT_SIZE, GRID_SLOT_SIZE, GRID_SLOT_SIZE);
-				}
+				if (processingState != -1 && pattern.get(i) == Boolean.TRUE)
+                {
+                    sv += (processingState == 0 ? 1 : -1) * (isShiftKeyDown() ? 4 : 1);
+                }
+				sv = MathHelper.clamp(sv, TileEntityMoldStation.MIN_DEPTH, TileEntityMoldStation.MAX_DEPTH);
+				if (sv > 0)
+                {
+				    drawTexturedModalRect(window_x + GRID_X + gx * GRID_SLOT_SIZE, window_y + GRID_Y + gy * GRID_SLOT_SIZE, GRID_OVERLAY_X, GRID_OVERLAY_Y + (sv - 1) * GRID_SLOT_SIZE, GRID_SLOT_SIZE, GRID_SLOT_SIZE);
+                }
 			}
 		}
 	}
@@ -120,13 +133,19 @@ public class GuiMoldStation extends GuiFoundry {
 			int x = (mousex - GRID_X - guiLeft) / GRID_SLOT_SIZE;
 			int y = (mousey - GRID_Y - guiTop) / GRID_SLOT_SIZE;
 
-			List<String> currenttip = new ArrayList<>();
-			currenttip.add("Depth: " + te_ms.getGridSlot(y * 6 + x));
+			List<String> currenttip = new ArrayList<>(1);
+			int depth = te_ms.getGridSlot(y * 6 + x);
+			if (processingState != -1 && pattern.get(y * 6 + x) == Boolean.TRUE)
+            {
+			    depth += (processingState == 0 ? 1 : -1) * (isShiftKeyDown() ? 4 : 1);
+            }
+			depth = MathHelper.clamp(depth, TileEntityMoldStation.MIN_DEPTH, TileEntityMoldStation.MAX_DEPTH);
+			currenttip.add("Depth: " + depth);
 			drawHoveringText(currenttip, mousex, mousey, fontRenderer);
 		}
 
 		if (isPointInRegion(117, 15, button_fire.width, button_fire.height, mousex, mousey)) {
-			List<String> currenttip = new ArrayList<>();
+			List<String> currenttip = new ArrayList<>(1);
 			currenttip.add("Fire mold");
 			drawHoveringText(currenttip, mousex, mousey, fontRenderer);
 		}
@@ -149,14 +168,49 @@ public class GuiMoldStation extends GuiFoundry {
 	@Override
 	protected void mouseClicked(int mouseX, int mouseY, int mouseButton) throws IOException {
 		super.mouseClicked(mouseX, mouseY, mouseButton);
-		if (te_ms.hasBlock() && isPointInRegion(GRID_X, GRID_Y, GRID_SIZE - 1, GRID_SIZE - 1, mouseX, mouseY)) {
-			int x = (mouseX - GRID_X - guiLeft) / GRID_SLOT_SIZE;
-			int y = (mouseY - GRID_Y - guiTop) / GRID_SLOT_SIZE;
-			if (mouseButton == 0) {
-				te_ms.carve(x, y, x, y);
-			} else {
-				te_ms.mend(x, y, x, y);
-			}
+		if (processingState == -1 &&
+		        te_ms.hasBlock() &&
+		        isPointInRegion(GRID_X, GRID_Y, GRID_SIZE - 1, GRID_SIZE - 1, mouseX, mouseY) &&
+		        mouseButton >= 0 &&
+		        mouseButton <= 1) {
+		    processingState = mouseButton;
+			selectSlot(mouseX, mouseY);
 		}
 	}
+
+	@Override
+	protected void mouseClickMove(int mouseX, int mouseY, int clickedMouseButton, long timeSinceLastClick)
+	{
+	    super.mouseClickMove(mouseX, mouseY, clickedMouseButton, timeSinceLastClick);
+	    if (processingState == clickedMouseButton)
+        {
+            selectSlot(mouseX, mouseY);
+        }
+	}
+
+	@Override
+	protected void mouseReleased(int mouseX, int mouseY, int state)
+	{
+	    super.mouseReleased(mouseX, mouseY, state);
+	    if (processingState == state)
+        {
+	        if (pattern.contains(Boolean.TRUE))
+            {
+	            int depth = (processingState == 0 ? 1 : -1) * (isShiftKeyDown() ? 4 : 1);
+	            te_ms.carve(pattern, depth);
+	            Collections.fill(pattern, Boolean.FALSE);
+            }
+	        processingState = -1; // No state.
+        }
+	}
+
+	private void selectSlot(int mouseX, int mouseY)
+    {
+        if (processingState != -1 && isPointInRegion(GRID_X, GRID_Y, GRID_SIZE - 1, GRID_SIZE - 1, mouseX, mouseY))
+        {
+            int x = (mouseX - GRID_X - guiLeft) / GRID_SLOT_SIZE;
+            int y = (mouseY - GRID_Y - guiTop) / GRID_SLOT_SIZE;
+            pattern.set(y * 6 + x, Boolean.TRUE);
+        }
+    }
 }

--- a/src/main/java/exter/foundry/tileentity/TileEntityMoldStation.java
+++ b/src/main/java/exter/foundry/tileentity/TileEntityMoldStation.java
@@ -98,7 +98,7 @@ public class TileEntityMoldStation extends TileEntityFoundry implements IExoflam
 		return has_block && current_recipe != null && canRecipeOutput();
 	}
 
-	public void carve(NonNullList<Boolean> pattern, int depth) {
+	public void carve(final NonNullList<Boolean> pattern, int depth) {
 		if (world.isRemote && has_block && pattern.size() == grid.length) {
 			NBTTagCompound tag = new NBTTagCompound();
 			for (int i = 0; i < grid.length; i++)
@@ -243,7 +243,7 @@ public class TileEntityMoldStation extends TileEntityFoundry implements IExoflam
 		return world.getTileEntity(getPos()) != this ? false : par1EntityPlayer.getDistanceSq(getPos()) <= 64.0D;
 	}
 
-	public void mend(NonNullList<Boolean> pattern, int depth) {
+	public void mend(final NonNullList<Boolean> pattern, int depth) {
 		carve(pattern, -depth);
 	}
 
@@ -323,7 +323,7 @@ public class TileEntityMoldStation extends TileEntityFoundry implements IExoflam
 			--burn_time;
 		}
 		if (has_block && progress >= 0) {
-			if (current_recipe == null) current_recipe = MoldRecipeManager.INSTANCE.findRecipe(this.grid);
+//			if (current_recipe == null) current_recipe = MoldRecipeManager.INSTANCE.findRecipe(this.grid);
 			if (burn_time == 0 && current_recipe != null && canRecipeOutput()) {
 				item_burn_time = burn_time = TileEntityFurnace.getItemBurnTime(getStackInSlot(SLOT_FUEL));
 				if (burn_time > 0) {

--- a/src/main/java/exter/foundry/tileentity/TileEntityMoldStation.java
+++ b/src/main/java/exter/foundry/tileentity/TileEntityMoldStation.java
@@ -11,7 +11,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fml.common.Optional;
@@ -24,6 +26,8 @@ public class TileEntityMoldStation extends TileEntityFoundry implements IExoflam
 	public static final int SLOT_CLAY = 1;
 	public static final int SLOT_OUTPUT = 2;
 	public static final int SLOT_FUEL = 3;
+	public static final int MIN_DEPTH = 0;
+	public static final int MAX_DEPTH = 4;
 
 	private int burn_time;
 
@@ -94,18 +98,21 @@ public class TileEntityMoldStation extends TileEntityFoundry implements IExoflam
 		return has_block && current_recipe != null && canRecipeOutput();
 	}
 
-	public void carve(int x1, int y1, int x2, int y2) {
-		if (world.isRemote && has_block) {
+	public void carve(NonNullList<Boolean> pattern, int depth) {
+		if (world.isRemote && has_block && pattern.size() == grid.length) {
 			NBTTagCompound tag = new NBTTagCompound();
-			for (int j = y1; j <= y2; j++) {
-				for (int i = x1; i <= x2; i++) {
-					int slot = j * 6 + i;
-					if (grid[slot] < 4) {
-						grid[slot]++;
-						tag.setInteger("RecipeGrid_" + slot, grid[slot]);
-					}
-				}
-			}
+			for (int i = 0; i < grid.length; i++)
+            {
+                if (pattern.get(i) == Boolean.TRUE)
+                {
+                    int depthNew = MathHelper.clamp(depth + grid[i], MIN_DEPTH, MAX_DEPTH);
+                    if (depthNew != grid[i])
+                    {
+                        grid[i] = depthNew;
+                        tag.setInteger("RecipeGrid_" + i, grid[i]);
+                    }
+                }
+            }
 			sendToServer(tag);
 		}
 	}
@@ -236,20 +243,8 @@ public class TileEntityMoldStation extends TileEntityFoundry implements IExoflam
 		return world.getTileEntity(getPos()) != this ? false : par1EntityPlayer.getDistanceSq(getPos()) <= 64.0D;
 	}
 
-	public void mend(int x1, int y1, int x2, int y2) {
-		if (world.isRemote && has_block) {
-			NBTTagCompound tag = new NBTTagCompound();
-			for (int j = y1; j <= y2; j++) {
-				for (int i = x1; i <= x2; i++) {
-					int slot = j * 6 + i;
-					if (grid[slot] > 0) {
-						grid[slot]--;
-						tag.setInteger("RecipeGrid_" + slot, grid[slot]);
-					}
-				}
-			}
-			sendToServer(tag);
-		}
+	public void mend(NonNullList<Boolean> pattern, int depth) {
+		carve(pattern, -depth);
 	}
 
 	@Override

--- a/src/main/resources/assets/foundry/lang/en_US.lang
+++ b/src/main/resources/assets/foundry/lang/en_US.lang
@@ -369,3 +369,7 @@ gui.jei.casting_table.ingot=Ingot Casting Table
 gui.jei.casting_table.plate=Plate Casting Table
 gui.jei.casting_table.rod=Rod Casting Table
 gui.jei.casting_table.block=Block Casting Table
+
+gui.foundry.mold=Mold Station
+gui.foundry.mold.depth=Depth: %d
+gui.foundry.mold.fire=Fire mold

--- a/src/main/resources/assets/foundry/lang/fr_FR.lang
+++ b/src/main/resources/assets/foundry/lang/fr_FR.lang
@@ -455,3 +455,7 @@ item.foundryContainer.name=Réservoir à liquide réfractaire
 tc.research.capmold.text=Ce moule permet de créer des capuchons de baguette avec du métal liquide. Après sa fabrication, ce moule doit être durci dans un four avant son utilisation. 
 tc.research_name.FOUNDRY_capmold=Moule à capuchons de baguette.
 tc.research_text.FOUNDRY_capmold=Faite des capuchons de baguette à partir du métal liquide.
+
+gui.foundry.mold=Mold Station
+gui.foundry.mold.depth=Depth: %d
+gui.foundry.mold.fire=Fire mold

--- a/src/main/resources/assets/foundry/lang/zh_CN.lang
+++ b/src/main/resources/assets/foundry/lang/zh_CN.lang
@@ -392,3 +392,7 @@ gui.jei.casting_table.ingot=锭铸造台
 gui.jei.casting_table.plate=板铸造台
 gui.jei.casting_table.rod=杆铸造台
 gui.jei.casting_table.block=方块铸造台
+
+gui.foundry.mold=Mold Station
+gui.foundry.mold.depth=Depth: %d
+gui.foundry.mold.fire=Fire mold


### PR DESCRIPTION
Hey. I love Foundry but I also get headache when I use the mold station gui. The interaction can be a pain especially making a block mold.

In this PR your can simply modify a queue of slot by simply dragging your mouse. And dragging when pressing SHIFT will allows you carve or mend 4 depth at one time.

Here is a brief demo.
![foundry_demo](https://user-images.githubusercontent.com/16059084/42274529-9a4b87c8-7fbf-11e8-83df-ad59af186d02.gif)

Also I added more i18n support and disabled auto recipe detection.